### PR TITLE
Fix Token Symbol From LPTEN to LPTAD

### DIFF
--- a/assets/js/staking.js
+++ b/assets/js/staking.js
@@ -405,7 +405,7 @@ var addLpToMetamask = async function(){
 	  type: 'ERC20', // Initially only supports ERC20, but eventually more!
 	  options: {
 		address: ENV.lpAddress, // The address that the token is at.
-		symbol: 'LPTEN', // A ticker symbol or shorthand, up to 5 chars.
+		symbol: 'LPTAD', // A ticker symbol or shorthand, up to 5 chars.
 		decimals: 18, // The number of decimals in the token
 		image: '', // A string url of the token logo
 	  },


### PR DESCRIPTION
on metamask, when click "add TAD/ETH LP to Metamask" on stake.html , it shows "LPTEN" token symbol instead "LPTAD"
This is Liquidity Provider Token Reward for TAD/ETH, Right?