### PR TITLE
"Can" to "Need To" Claim Manually Staking Reward

### DIFF
--- a/staking.html
+++ b/staking.html
@@ -195,7 +195,7 @@
 								<div class="card-body">
 									<h4 class="card-title">Claim</h4>
 									<p class="card-title-desc">
-										You can manually claim your TAD token reward into your wallet. Beware that you need to spend some ethereum gas. You may claim anytime, during or after the staking period.
+										You need to manually claim your TAD token reward into your wallet. Beware that you need to spend some ethereum gas. You may claim anytime, during or after the staking period.
 									</p>
 									
 									<form>


### PR DESCRIPTION
Users need to manually claim TAD Reward, Right?
Except they're Add More/Remove LPTAD Token from Staking Program, it'll Automatically Claim their TAD Reward
This Fix is On "Claim" Card, Which is They need to manually press the "Claim" Button.