### PR TITLE
fix typo "2 year" to "2 years"

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -243,7 +243,7 @@
                                                         <p class="text-muted">Total supply of TAD is 1,000,000 TAD.</p>
                                                         <ul>
 															<li><b>Genesis Mining</b>: 200,000 (20%) (30 days period)</li>
-															<li><b>Platform Liquidity Mining</b>: 500,000 (50%) (2 year period)</li>
+															<li><b>Platform Liquidity Mining</b>: 500,000 (50%) (2 years period)</li>
 															<li><b>DEX Liquidity Mining</b>: 200,000 (20%) (1 year period)</li>
 															<li><b>Developer Rewards</b>: 100,000 (10%) (1 year period)</li>
 														</ul>


### PR DESCRIPTION
2 (two) is Plural sir must adding "s" --- typo "2 year" to "2 years"

wallet: 0xE04E0Fec2D4b37bF5860ACbEbA99B72FC2975a04