### PR TITLE
Fix Cursor "Hand" on Boxes of Staking &Genesis

### DIFF
--- a/staking.html
+++ b/staking.html
@@ -139,7 +139,7 @@
 						</div>
 					</div>
                     
-                    <div class="row coins_container justify-content-md-center">
+                    <div class="row justify-content-md-center">
 						
 
                         <div class="col-lg-4 mb-5">
@@ -271,7 +271,7 @@
                     <!-- end row -->
                     
                     
-                    <div class="row coins_container justify-content-md-center">
+                    <div class="row justify-content-md-center">
 						
                         <div class="col-8 mb-2">
 							<h5>Your Staking</h5>


### PR DESCRIPTION
this is solution of my issue : https://github.com/Tadpole-finance/tadpole-finance.github.io/issues/43#issue-771329361
I think this class ( coins_container) not used in box of staking and genesis, because style only {margin-bottom: 1px; cursor: pointer;}
I remove this css class from staking.html & genesis.html to fixing Cursor Hand

this my wallet sir: 0xE04E0Fec2D4b37bF5860ACbEbA99B72FC2975a04