### PR TITLE
Fix unresponsive View Header from Smart Phone + tested

### DIFF
--- a/header.html
+++ b/header.html
@@ -6,7 +6,7 @@
                             <a href="index.html" class="logo logo-dark">
 								<picture>
 									<source media="(min-width: 450px)" srcset="assets/images/new-logo/Logo-tadpole.png">
-									<img src="assets/images/new-logo/Logo-tadpole.png" alt="" height="35px">
+									<img src="assets/images/new-logo/Logo-tadpole.png" alt="" class="img-fluid" style="max-height: 35px">
 								</picture>
                                 
                             </a>
@@ -55,12 +55,11 @@
                             </nav>
                         </div>
                     </div>
-
-
-					<div class="dropdown">
-                        <div class=" d-inline-block metamask-container">
+			<div class=" d-inline-block metamask-container">
                             <button class="btn btn-info btn-sm" onclick="connectMetamask(); return false;" id="btn_connect_metamask">Connect<span> to MetaMask</span></button>
                         </div>
+			<div class="dropdown">
+                        
                         <button type="button" class=" btn btn-sm px-3 font-size-16 d-lg-none header-item " data-toggle="collapse" data-target="#topnav-menu-content">
                             <i class="fa fa-fw fa-bars"></i>
                         </button>


### PR DESCRIPTION
this solution from : #62 
Fix Responsive View Header from Smart Phone and put out metamask button from drop down, for fix Responsive view.
(class="img-fluid" style="max-height: 35px" ) line 9 header **img-fluid** for responsive image,  **style="max-height: 35px"** for if open by web browser with high resolution it constan max height such as before, but before only height not max-height. It using max height for support responsive if using phone or other device with little viewing.
**other change put out metamask button for take place in left if using little view. it become better then before.

this my test for responsive after : 
https://user-images.githubusercontent.com/74474384/104070366-4ccc4100-5239-11eb-926c-25431ff27a33.mp4

