### PR TITLE
tadpole enable collateral bug

### DIFF
--- a/assets/js/tadpole.js
+++ b/assets/js/tadpole.js
@@ -388,10 +388,11 @@ var updateBorrowLimit = async function(borrowInUsd){
 var enableCollateral = async function(id){
 	
 	if(!account){
-		Swal.fire(
-		  'Error',
-		  'Connect MetaMask to continue.',
-		  'error'
+		$('.'+cTokenId+'_is_collateral').prop( "checked", false );
+			Swal.fire(
+				'Error',
+				'Connect MetaMask to continue.',
+				'error'		
 		)
 		return;
 	}

--- a/faq.html
+++ b/faq.html
@@ -230,7 +230,7 @@
                                                         <p class="text-muted">Platform Liquidity Mining (upcoming) is a reward program to motivate saving and borrowing activities in Tadpole Finance. In addition to saving interest, a number of TAD is distributed to both savers and borrowers according to the size of the savings & the loan portion.</p>
                                                         <p class="text-muted">DEX Liquidity Mining is a reward mechanism to ensure the liquidity of TAD and the supporting tokens are always maintained on decentralized exchanges. You can get TAD token by staking Uniswap LP tokens.</p>
                                                         <p class="text-muted">Developer Rewards program is distributed to all developers that are involved in developing Tadpole Finance platform.</p>
-                                                        <p class="text-muted">Lastly you can get TAD by getting it through Uniswap.</p>
+                                                        <p class="text-muted">Lastly you can get TAD by getting it through Uniswap and another exchanges(bithumb global, consbit, and hotbit(per january).</p> #add another exchanges
                                                     </div>
                                                 </div>
                                                 
@@ -326,7 +326,7 @@
                                                         <p class="text-muted">Make sure you hold the token you want to deposit, and small amount of ETH in your Metamask wallet. The ETH will be used to pay the transaction gas fee.</p>
                                                         <ol>
 															<li>Go to Tadpole.finance.</li>
-															<li>on the supply side, click on the token you want to deposit.</li>
+															<li>On the supply side, click on the token you want to deposit.</li>#on to On
 															<li>(skip if you deposited this token before) If you've never deposited this token before, it will ask you to approve allowance for the Tadpole Finance smart contract to pull your tokens. Click OK, approve the transaction through your Metamask wallet, then wait the transaction to be mined.</li>
 															<li>(skip if you deposited this token before) Click on the token you want to deposit again</li>
 															<li>Enter the amount of token you want to deposit, click continue.</li>

--- a/faq.html
+++ b/faq.html
@@ -230,7 +230,7 @@
                                                         <p class="text-muted">Platform Liquidity Mining (upcoming) is a reward program to motivate saving and borrowing activities in Tadpole Finance. In addition to saving interest, a number of TAD is distributed to both savers and borrowers according to the size of the savings & the loan portion.</p>
                                                         <p class="text-muted">DEX Liquidity Mining is a reward mechanism to ensure the liquidity of TAD and the supporting tokens are always maintained on decentralized exchanges. You can get TAD token by staking Uniswap LP tokens.</p>
                                                         <p class="text-muted">Developer Rewards program is distributed to all developers that are involved in developing Tadpole Finance platform.</p>
-                                                        <p class="text-muted">Lastly you can get TAD by getting it through Uniswap and another exchanges(bithumb global, consbit, and hotbit(per january).</p> #add another exchanges
+                                                        <p class="text-muted">Lastly you can get TAD by getting it through Uniswap.</p>
                                                     </div>
                                                 </div>
                                                 
@@ -326,7 +326,7 @@
                                                         <p class="text-muted">Make sure you hold the token you want to deposit, and small amount of ETH in your Metamask wallet. The ETH will be used to pay the transaction gas fee.</p>
                                                         <ol>
 															<li>Go to Tadpole.finance.</li>
-															<li>On the supply side, click on the token you want to deposit.</li>#on to On
+															<li>on the supply side, click on the token you want to deposit.</li>
 															<li>(skip if you deposited this token before) If you've never deposited this token before, it will ask you to approve allowance for the Tadpole Finance smart contract to pull your tokens. Click OK, approve the transaction through your Metamask wallet, then wait the transaction to be mined.</li>
 															<li>(skip if you deposited this token before) Click on the token you want to deposit again</li>
 															<li>Enter the amount of token you want to deposit, click continue.</li>


### PR DESCRIPTION
I think there is a bug on tadpole finance landing page.
When we click enable button on suppy feature without connecting to ghoerly network metamask, it will throw an error.
But when we close the pop up, the button have moved to enabled state, not go back to disable state. I think it will be a problem for general people that not familiar with defi system.
Maybe you can see the compound app for comparison. Thank you

address : 0xb22e90360f345338990D973d3675F8db6f765346
