### PR TITLE
Missing Alt in Image Tadpole Finance Logo

### DIFF
--- a/header.html
+++ b/header.html
@@ -6,7 +6,7 @@
                             <a href="index.html" class="logo logo-dark">
 								<picture>
 									<source media="(min-width: 450px)" srcset="assets/images/new-logo/Logo-tadpole.png">
-									<img src="assets/images/new-logo/Logo-tadpole.png" alt="" height="35px">
+									<img src="assets/images/new-logo/Logo-tadpole.png" alt="Tadpole Logo" height="35px">
 								</picture>
                                 
                             </a>
@@ -40,8 +40,13 @@
                                             </a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link dropdown-toggle arrow-none" href="./faq.html" role="button">
-                                                FAQ
+                                            <a class="nav-link dropdown-toggle arrow-none" href="https://doc.tadpole.finance/" role="button" target="blank">
+                                                Docs
+                                            </a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link dropdown-toggle arrow-none" href="https://uniswap.tadpole.finance/" role="button" target="blank">
+                                                Uniswap
                                             </a>
                                         </li>
 


### PR DESCRIPTION
The alt attribute is used to describe image. Search engines will use it to understand content of logo tadpole and if the user browser disable the image feature, its show nothing and cannot click the image.