### PR TITLE
Fix Unresponsive View from Smart Phone & Desktop [Tested]

### DIFF
--- a/header.html
+++ b/header.html
@@ -6,7 +6,7 @@
                             <a href="index.html" class="logo logo-dark">
 								<picture>
 									<source media="(min-width: 450px)" srcset="assets/images/new-logo/Logo-tadpole.png">
-									<img src="assets/images/new-logo/Logo-tadpole.png" alt="" height="35px">
+									<img src="assets/images/new-logo/Logo-tadpole.png" alt="" class="img-fluid" style="max-height: 35px">
 								</picture>
                                 
                             </a>
@@ -57,7 +57,7 @@
                     </div>
 
 
-					<div class="dropdown">
+					<div class="dropdown" style="min-width:140px">
                         <div class=" d-inline-block metamask-container">
                             <button class="btn btn-info btn-sm" onclick="connectMetamask(); return false;" id="btn_connect_metamask">Connect<span> to MetaMask</span></button>
                         </div>


### PR DESCRIPTION
this solution from : #62  
Fix Responsive View Header from Smart Phone and put out metamask button from drop down, for fix Responsive view.
(class="img-fluid" style="max-height: 35px" ) line 9 header img-fluid for responsive image, style="max-height: 35px" for if open by web browser with high resolution it constan max height such as before, but before only height not max-height. It using max height for support responsive if using phone or other device with little viewing.
other change adding style at <div class="dropdown" style="min-width:150px"> to fix button in Smartphone and desktop view not affected.
this test video  : 
https://user-images.githubusercontent.com/74474384/104334681-3d911000-5525-11eb-899b-527deae75c60.mp4